### PR TITLE
add link to KubeConEU notes and upcoming...

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ Or Telephone:
 
 ## In Person Meetings
 
-[@pragashj](https://github.com/pragashj) is working with [@cra](https://github.com/cra) to line up space for an in person meeting at [KubeConEU](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2018/) May 2-4, 2018 in Copenhagen, Denmark.
+Please let us know if you are going and if you are interested in attending (or helping to organize!) an in-person meetup (via the linked github issue):
+* KubeCon + CloudNativeCon, Shanghai, Nov 14-15, 2018 - [issue#28](https://github.com/cn-security/safe/issues/28) 
+* KubeCon + CloudNativeCon, North America, Dec 11-13, 2018 - [issue#29](https://github.com/cn-security/safe/issues/29)
+
+Past
+* [KubeConEU](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2018/) May 2-4, 2018 in Copenhagen, Denmark ([notes](safe_kubecon.md))
 
 ## Meeting Minutes
 


### PR DESCRIPTION
added github issues for upcoming conferences where we might have in-person meetups

follow-up from 2018-05-25 SAFE Meeting, [see notes](https://docs.google.com/document/d/1LEXzz1PUaboqyIBg-1QBj-R0T1z6950fsetkBEW7b8g/edit#)