### PR TITLE
move roadmap from google doc to markdown

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,30 @@
+# SAFE WG Roadmap
+
+### Overview
+
+|     | #2 Discover | #3 Describe | #4 Identify
+| --- | --- | --- | --- |
+| Artifacts | Personas<br/>Use Cases<br/>Categories | Standards<br/>Common Definitions<br/>Block Architecture | Catalog Projects<br/>Fill in Boxes<br/>Identify Gaps
+| Topics | Presentations<br/>WG members & guests | Standards in Practice<br/>Real World Systems Architecture | Platforms & Products<br/>Tools & Libraries
+
+### Details
+
+1. **Charter** the working group. Draft vision, process and initial members (done)
+2. **Discover** (in progress)
+   * Explore the problem space of the working group
+   * Investigating what is happening in the community today with respect to security for cloud native applications and infrastructure
+   * [Presentations](issues?utf8=%E2%9C%93&q=is%3Aclosed+is%3Aissue+label%3Ausecase-presentation+) from members & guests
+   * Describe [personas & use cases](safe_usecases.md)
+   * Draft a picture or set of categories that will serve as a starting point for an evaluation framework
+3. **Describe** the landscape
+   * Define the terminology used in the output documents, and in the community
+   * Describe the current state (landscape) of cloud native security, which might include:
+      * existing standards
+      * existing open source, and proprietary, solutions
+      * common patterns in use today for system that works for cloud-native apps. For example:
+        * Extract end-to-end view of secure access, and
+        * Common layering or a block architecture
+4. **Identify** existing security components in CNCF and projects in the CNCF landscape and catalog
+   * Identify gaps and make recommendations to the community and TOC
+   * Continually monitor the viability of the existing projects and update the landscape document
+


### PR DESCRIPTION
fixed #48

note this overview of our roadmap was included in the slides for [4/17 TOC meeting](https://docs.google.com/presentation/d/1QsBRsPU8E7AovvIGC-QIjxcfeQMcLd47iAzpoMFliII/edit#slide=id.g36fd28bfd4_5_8)
